### PR TITLE
refactor: externalize spanish strings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Header } from "./components/Header";
 import { SideMenu } from "./components/SideMenu";
 import { ChatArea } from "./components/ChatArea";
 import { RequirementsTable } from "./components/RequirementsTable";
+import { getTranslations, type Language } from "./i18n";
 import type { ProjectModel } from "./models/project-model";
 import type { UserModel } from "./models/user-model";
 import { SettingsPage } from "./pages/SettingsPage";
@@ -25,6 +26,7 @@ interface AppProps {
 export default function App({ isDarkMode, onToggleDarkMode }: AppProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [language, setLanguage] = useState("es");
+  const t = getTranslations(language as Language);
   const [user, setUser] = useState<UserModel | null>(null);
   const [loadingUser, setLoadingUser] = useState(true);
 
@@ -133,7 +135,7 @@ export default function App({ isDarkMode, onToggleDarkMode }: AppProps) {
     } catch (e: any) {
       // Si fue 401, el interceptor ya navegó; aquí solo limpiamos estado local
       setChatMessages([]);
-      setErrorChat("No se pudieron cargar los mensajes.");
+      setErrorChat(t.errorLoadMessages);
     } finally {
       setLoadingChat(false);
     }
@@ -150,7 +152,7 @@ export default function App({ isDarkMode, onToggleDarkMode }: AppProps) {
       await sendMessage(msg);
       await reloadMessages();
     } catch (e: any) {
-      setErrorChat("No se pudo enviar el mensaje.");
+      setErrorChat(t.errorSendMessage);
     } finally {
       setLoadingChat(false);
     }
@@ -176,7 +178,7 @@ export default function App({ isDarkMode, onToggleDarkMode }: AppProps) {
       // Recarga mensajes (sincroniza state también)
       await reloadMessages();
     } catch (e) {
-      setErrorChat("No se pudo analizar con IA.");
+      setErrorChat(t.errorAnalyzeAI);
     } finally {
       setLoadingChat(false);
     }
@@ -272,10 +274,10 @@ export default function App({ isDarkMode, onToggleDarkMode }: AppProps) {
                   >
                     <CircularProgress color="inherit" sx={{ mb: 2 }} />
                     <Typography variant="h6">
-                      Su respuesta está siendo procesada por la IA.
+                      {t.processingResponse}
                     </Typography>
                     <Typography variant="body2" color="inherit" sx={{ mt: 1 }}>
-                      Podría tardar hasta un minuto. Por favor, espere...
+                      {t.processingWait}
                     </Typography>
                   </Backdrop>
 

--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -261,10 +261,10 @@ export function ChatArea({
                         color="primary"
                         size="small"
                         disabled={loading}
-                        onClick={() => console.log("Añadir R. Funcionales")}
+                        onClick={() => console.log(t.chatStallAddFunctional)}
                         sx={{ whiteSpace: "nowrap" }}
                       >
-                        Añadir R. Funcionales
+                        {t.chatStallAddFunctional}
                       </Button>
 
                       <Button
@@ -276,7 +276,7 @@ export function ChatArea({
                         disabled={loading}
                         sx={{ whiteSpace: "nowrap" }}
                       >
-                        Añadir R. No Funcionales
+                        {t.chatStallAddNonFunctional}
                       </Button>
                       <Menu
                         anchorEl={anchorEl}
@@ -284,10 +284,10 @@ export function ChatArea({
                         onClose={handleCloseMenu}
                         MenuListProps={{ dense: true }}
                       >
-                        <MenuItem onClick={() => { console.log("performance"); handleCloseMenu(); }}>Performance</MenuItem>
-                        <MenuItem onClick={() => { console.log("usability"); handleCloseMenu(); }}>Usability</MenuItem>
-                        <MenuItem onClick={() => { console.log("security"); handleCloseMenu(); }}>Security</MenuItem>
-                        <MenuItem onClick={() => { console.log("technical"); handleCloseMenu(); }}>Technical</MenuItem>
+                        <MenuItem onClick={() => { console.log("performance"); handleCloseMenu(); }}>{t.category.performance}</MenuItem>
+                        <MenuItem onClick={() => { console.log("usability"); handleCloseMenu(); }}>{t.category.usability}</MenuItem>
+                        <MenuItem onClick={() => { console.log("security"); handleCloseMenu(); }}>{t.category.security}</MenuItem>
+                        <MenuItem onClick={() => { console.log("technical"); handleCloseMenu(); }}>{t.category.technical}</MenuItem>
                       </Menu>
                     </Stack>
                   </Box>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -40,7 +40,7 @@ export function Header({
         <IconButton
           edge="start"
           color="inherit"
-          aria-label={t.toggleMenu || "Abrir menú"}
+          aria-label={t.toggleMenu}
           onClick={onToggleMenu}
           sx={{ mr: 2 }}
         >
@@ -69,11 +69,11 @@ export function Header({
             variant="standard"
             disableUnderline
             sx={{ fontWeight: 500, minWidth: 70 }}
-            title={t.selectLanguage || "Seleccionar idioma"}
+            title={t.selectLanguage}
           >
-            <MenuItem value="en">English</MenuItem>
-            <MenuItem value="es">Español</MenuItem>
-            <MenuItem value="ca">Català</MenuItem>
+            <MenuItem value="en">{t.languages.en}</MenuItem>
+            <MenuItem value="es">{t.languages.es}</MenuItem>
+            <MenuItem value="ca">{t.languages.ca}</MenuItem>
           </Select>
         </Box>
 

--- a/src/components/RequirementsTable.tsx
+++ b/src/components/RequirementsTable.tsx
@@ -83,7 +83,7 @@ export function RequirementsTable({ collapsed, onToggleCollapse, language, proje
     setLoading(true);
     fetchProjectRequirements(projectId)
       .then(setRequirements)
-      .catch(() => setError("No se pudieron cargar los requisitos"))
+      .catch(() => setError(t.errorLoadRequirements))
       .finally(() => setLoading(false));
   }, [projectId]);
 
@@ -143,7 +143,7 @@ export function RequirementsTable({ collapsed, onToggleCollapse, language, proje
       setEditingId(null);
       setEditForm({});
     } catch (err: any) {
-      setError("No se pudo actualizar el requisito");
+      setError(t.errorUpdateRequirement);
     } finally {
       setLoading(false);
     }
@@ -156,7 +156,7 @@ export function RequirementsTable({ collapsed, onToggleCollapse, language, proje
       await deleteRequirementApi(id);
       setRequirements(prev => prev.filter(req => req.id !== id));
     } catch (err: any) {
-      setError("No se pudo eliminar el requisito");
+      setError(t.errorDeleteRequirement);
     } finally {
       setLoading(false);
     }
@@ -177,7 +177,7 @@ export function RequirementsTable({ collapsed, onToggleCollapse, language, proje
       setRequirements(prev => [...prev, created]);
       startEdit(created);
     } catch (err: any) {
-      setError("No se pudo crear el requisito");
+      setError(t.errorCreateRequirement);
     } finally {
       setLoading(false);
     }

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -60,7 +60,7 @@ export function SideMenu({
   const handleAddProject = async () => {
     setError("");
     if (!projName.trim()) {
-      setError("El nombre es obligatorio");
+      setError(t.errorProjectNameRequired);
       return;
     }
     setSaving(true);
@@ -74,7 +74,7 @@ export function SideMenu({
       setOpenNewProjectModal(false);
       onClose(); // Cierra SideMenu
     } catch (err: any) {
-      setError("Error al crear el proyecto");
+      setError(t.errorCreateProject);
     } finally {
       setSaving(false);
     }
@@ -208,11 +208,11 @@ export function SideMenu({
         maxWidth="xs"
         fullWidth
       >
-        <DialogTitle>Añadir nuevo proyecto</DialogTitle>
+        <DialogTitle>{t.newProjectTitle}</DialogTitle>
         <DialogContent>
           <Stack spacing={2} mt={1}>
             <TextField
-              label="Nombre del proyecto"
+              label={t.newProjectNameLabel}
               value={projName}
               onChange={e => setProjName(e.target.value)}
               required
@@ -220,7 +220,7 @@ export function SideMenu({
               autoFocus
             />
             <TextField
-              label="Descripción"
+              label={t.newProjectDescriptionLabel}
               value={projDesc}
               onChange={e => setProjDesc(e.target.value)}
               multiline
@@ -236,14 +236,14 @@ export function SideMenu({
         </DialogContent>
         <DialogActions sx={{ px: 3, pb: 2 }}>
           <Button onClick={handleCancelNewProject} disabled={saving}>
-            Cancelar
+            {t.newProjectCancel}
           </Button>
           <Button
             onClick={handleAddProject}
             variant="contained"
             disabled={saving}
           >
-            {saving ? "Guardando..." : "Crear proyecto"}
+            {saving ? t.newProjectSaving : t.newProjectCreate}
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/components/settings/SettingsPreferencesSection.tsx
+++ b/src/components/settings/SettingsPreferencesSection.tsx
@@ -62,9 +62,9 @@ export function SettingsPreferencesSection({ user, onUpdate, language, onLanguag
             label={t.settingsPrefsLangLabel}
             onChange={e => onLanguageChange(e.target.value)}
           >
-            <MenuItem value="es">Español</MenuItem>
-            <MenuItem value="en">English</MenuItem>
-            <MenuItem value="ca">Català</MenuItem>
+            <MenuItem value="es">{t.languages.es}</MenuItem>
+            <MenuItem value="en">{t.languages.en}</MenuItem>
+            <MenuItem value="ca">{t.languages.ca}</MenuItem>
           </Select>
         </FormControl>
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -6,6 +6,13 @@ type Translations = {
 
 const translations: Record<Language, Translations> = {
   en: {
+    // App
+    processingResponse: "Your response is being processed by the AI.",
+    processingWait: "It may take up to a minute. Please wait...",
+    errorLoadMessages: "Failed to load messages.",
+    errorSendMessage: "Failed to send the message.",
+    errorAnalyzeAI: "Failed to analyze with AI.",
+
     // ChatArea
     chatTitle: "AI Assistant",
     aiInitialMessage: "Hello! How can I help you with your project requirements today?",
@@ -54,6 +61,10 @@ const translations: Record<Language, Translations> = {
     saveChanges: "Save Changes",
     cancelEdit: "Cancel Edit",
     viewVisual: "View Visual Reference",
+    errorLoadRequirements: "Failed to load requirements",
+    errorUpdateRequirement: "Failed to update requirement",
+    errorDeleteRequirement: "Failed to delete requirement",
+    errorCreateRequirement: "Failed to create requirement",
     status: {
       draft: "Draft",
       'in-review': "In Review",
@@ -81,11 +92,26 @@ const translations: Record<Language, Translations> = {
     addProject: "Add Project",
     settings: "Settings",
     logout: "Logout",
+    // SideMenu - New Project Modal
+    newProjectTitle: "Add new project",
+    newProjectNameLabel: "Project name",
+    newProjectDescriptionLabel: "Description",
+    newProjectCancel: "Cancel",
+    newProjectSaving: "Saving...",
+    newProjectCreate: "Create project",
+    errorProjectNameRequired: "Name is required",
+    errorCreateProject: "Error creating project",
 
     // Header
     headerTitle: "Requirements Manager - {activeProject}",
     toggleMenu: "Toggle menu",
     selectLanguage: "Select language",
+    // Languages
+    languages: {
+      en: "English",
+      es: "Spanish",
+      ca: "Catalan",
+    },
 
     // Settings Page
     settingsTitle: "Settings",
@@ -140,6 +166,13 @@ const translations: Record<Language, Translations> = {
     loginLink: "Login",
   },
   es: {
+    // App
+    processingResponse: "Su respuesta está siendo procesada por la IA.",
+    processingWait: "Podría tardar hasta un minuto. Por favor, espere...",
+    errorLoadMessages: "No se pudieron cargar los mensajes.",
+    errorSendMessage: "No se pudo enviar el mensaje.",
+    errorAnalyzeAI: "No se pudo analizar con IA.",
+
     // ChatArea
     chatTitle: "Asistente IA",
     aiInitialMessage: "¡Hola! ¿Cómo puedo ayudarte con los requisitos de tu proyecto hoy?",
@@ -188,6 +221,10 @@ const translations: Record<Language, Translations> = {
     saveChanges: "Guardar Cambios",
     cancelEdit: "Cancelar Edición",
     viewVisual: "Ver Referencia Visual",
+    errorLoadRequirements: "No se pudieron cargar los requisitos",
+    errorUpdateRequirement: "No se pudo actualizar el requisito",
+    errorDeleteRequirement: "No se pudo eliminar el requisito",
+    errorCreateRequirement: "No se pudo crear el requisito",
     status: {
       draft: "Borrador",
       'in-review': "En Revisión",
@@ -215,11 +252,26 @@ const translations: Record<Language, Translations> = {
     addProject: "Añadir Proyecto",
     settings: "Configuración",
     logout: "Cerrar Sesión",
+    // SideMenu - New Project Modal
+    newProjectTitle: "Añadir nuevo proyecto",
+    newProjectNameLabel: "Nombre del proyecto",
+    newProjectDescriptionLabel: "Descripción",
+    newProjectCancel: "Cancelar",
+    newProjectSaving: "Guardando...",
+    newProjectCreate: "Crear proyecto",
+    errorProjectNameRequired: "El nombre es obligatorio",
+    errorCreateProject: "Error al crear el proyecto",
 
     // Header
     headerTitle: "Gestor de Requisitos - {activeProject}",
     toggleMenu: "Abrir/cerrar menú",
     selectLanguage: "Seleccionar idioma",
+    // Languages
+    languages: {
+      en: "Inglés",
+      es: "Español",
+      ca: "Catalán",
+    },
 
     // Settings Page
     settingsTitle: "Configuración",
@@ -274,6 +326,13 @@ const translations: Record<Language, Translations> = {
     loginLink: "Inicia sesión",
   },
   ca: {
+    // App
+    processingResponse: "La teva resposta està sent processada per la IA.",
+    processingWait: "Podria trigar fins a un minut. Si us plau, espera...",
+    errorLoadMessages: "No s'han pogut carregar els missatges.",
+    errorSendMessage: "No s'ha pogut enviar el missatge.",
+    errorAnalyzeAI: "No s'ha pogut analitzar amb IA.",
+
     // ChatArea
     chatTitle: "Assistent IA",
     aiInitialMessage: "Hola! Com puc ajudar-te amb els requisits del teu projecte avui?",
@@ -322,6 +381,10 @@ const translations: Record<Language, Translations> = {
     saveChanges: "Desar Canvis",
     cancelEdit: "Cancel·lar Edició",
     viewVisual: "Veure Referència Visual",
+    errorLoadRequirements: "No s'han pogut carregar els requisits",
+    errorUpdateRequirement: "No s'ha pogut actualitzar el requisit",
+    errorDeleteRequirement: "No s'ha pogut eliminar el requisit",
+    errorCreateRequirement: "No s'ha pogut crear el requisit",
     status: {
       draft: "Esborrany",
       'in-review': "En Revisió",
@@ -349,11 +412,26 @@ const translations: Record<Language, Translations> = {
     addProject: "Afegir Projecte",
     settings: "Configuració",
     logout: "Tancar Sessió",
+    // SideMenu - New Project Modal
+    newProjectTitle: "Afegir nou projecte",
+    newProjectNameLabel: "Nom del projecte",
+    newProjectDescriptionLabel: "Descripció",
+    newProjectCancel: "Cancel·lar",
+    newProjectSaving: "Desant...",
+    newProjectCreate: "Crear projecte",
+    errorProjectNameRequired: "El nom és obligatori",
+    errorCreateProject: "Error en crear el projecte",
 
     // Header
     headerTitle: "Gestor de Requisits - {activeProject}",
     toggleMenu: "Obrir/tancar menú",
     selectLanguage: "Seleccionar idioma",
+    // Languages
+    languages: {
+      en: "Anglès",
+      es: "Espanyol",
+      ca: "Català",
+    },
 
     // Settings Page
     settingsTitle: "Configuració",


### PR DESCRIPTION
## Summary
- externalize Spanish strings from App, SideMenu, RequirementsTable, ChatArea, Header, and SettingsPreferencesSection
- add translation keys for app messages, requirement errors, side menu modal, and language names
- wire components to use `getTranslations` and new keys

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Empty block statement and unexpected any in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_6898562551008332b4ad554e4ebedad2