### PR TITLE
Use typed Language state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { fetchProjectMessages, sendMessage, type ChatMessageCreatePayload } from
 import type { MessageModel } from "./models/message-model";
 import { CircularProgress, Typography, Backdrop } from "@mui/material";
 import { addStateMachineEntry } from "./services/state-machine-service";
+import type { Language } from "./i18n";
 
 interface AppProps {
   isDarkMode: boolean;
@@ -24,7 +25,7 @@ interface AppProps {
 
 export default function App({ isDarkMode, onToggleDarkMode }: AppProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [language, setLanguage] = useState("es");
+  const [language, setLanguage] = useState<Language>("es");
   const [user, setUser] = useState<UserModel | null>(null);
   const [loadingUser, setLoadingUser] = useState(true);
 
@@ -221,7 +222,7 @@ export default function App({ isDarkMode, onToggleDarkMode }: AppProps) {
           setIsMenuOpen(false);
           navigate("/login", { replace: true });
         }}
-        language={language as "en" | "es" | "ca"}
+        language={language}
         onSettings={() => {
           setIsMenuOpen(false);
           navigate("/settings");
@@ -290,7 +291,7 @@ export default function App({ isDarkMode, onToggleDarkMode }: AppProps) {
                       showFiles={showFiles}
                       collapsed={isChatCollapsed}
                       onToggleCollapse={() => setIsChatCollapsed((c) => !c)}
-                      language={language as "en" | "es" | "ca"}
+                      language={language}
                       projectId={activeProject?.id || 0}
                     />
                   </Box>
@@ -301,7 +302,7 @@ export default function App({ isDarkMode, onToggleDarkMode }: AppProps) {
                       <RequirementsTable
                         collapsed={isReqsCollapsed}
                         onToggleCollapse={() => setIsReqsCollapsed((c) => !c)}
-                        language={language as "en" | "es" | "ca"}
+                        language={language}
                         ownerId={user.id}
                         projectId={activeProject.id}
                       />
@@ -322,7 +323,7 @@ export default function App({ isDarkMode, onToggleDarkMode }: AppProps) {
                 <SettingsPage
                   user={user}
                   onUpdate={() => { }}
-                  language={language as "en" | "es" | "ca"}
+                  language={language}
                   onLanguageChange={setLanguage}
                 />
               ) : (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,8 +14,8 @@ interface HeaderProps {
   isDarkMode: boolean;
   onToggleDarkMode: () => void;
   onToggleMenu: () => void;
-  language: string;
-  onLanguageChange: (language: string) => void;
+  language: Language;
+  onLanguageChange: (language: Language) => void;
 }
 
 export function Header({
@@ -26,7 +26,7 @@ export function Header({
   language,
   onLanguageChange
 }: HeaderProps) {
-  const t = getTranslations(language as Language);
+  const t = getTranslations(language);
 
   return (
     <AppBar
@@ -64,7 +64,7 @@ export function Header({
           <LanguageIcon sx={{ mr: 1 }} fontSize="small" />
           <Select
             value={language}
-            onChange={(e) => onLanguageChange(e.target.value as string)}
+            onChange={(e) => onLanguageChange(e.target.value as Language)}
             size="small"
             variant="standard"
             disableUnderline

--- a/src/components/settings/SettingsPreferencesSection.tsx
+++ b/src/components/settings/SettingsPreferencesSection.tsx
@@ -20,7 +20,7 @@ interface SettingsPreferencesSectionProps {
   user: UserModel;
   onUpdate?: (user: UserModel) => void;
   language: Language;
-  onLanguageChange: (lang: string) => void;
+  onLanguageChange: (lang: Language) => void;
 }
 
 export function SettingsPreferencesSection({ user, onUpdate, language, onLanguageChange }: SettingsPreferencesSectionProps) {
@@ -60,7 +60,7 @@ export function SettingsPreferencesSection({ user, onUpdate, language, onLanguag
             labelId="language-label"
             value={language}
             label={t.settingsPrefsLangLabel}
-            onChange={e => onLanguageChange(e.target.value)}
+            onChange={e => onLanguageChange(e.target.value as Language)}
           >
             <MenuItem value="es">Español</MenuItem>
             <MenuItem value="en">English</MenuItem>

--- a/src/models/user-model.ts
+++ b/src/models/user-model.ts
@@ -1,3 +1,5 @@
+import type { Language } from "../i18n";
+
 export type UserModel = {
     id: number;
     username: string;
@@ -16,7 +18,7 @@ export type UserModel = {
 export type UserPreferences = {
     theme: string;
     notifications: boolean;
-    language: string;
+    language: Language;
     timezone: string;
 };
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -21,7 +21,7 @@ interface SettingsPageProps {
   user: UserModel;
   onUpdate?: (user: UserModel) => void;
   language: Language;
-  onLanguageChange: (lang: string) => void;
+  onLanguageChange: (lang: Language) => void;
 }
 
 export function SettingsPage({ user, onUpdate, language, onLanguageChange }: SettingsPageProps) {

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -2,6 +2,7 @@
 import { api } from "./api";
 import type { MessageModel } from "../models/message-model";
 import type { StateMachineState } from "../context/StateMachineContext";
+import type { Language } from "../i18n";
 
 // === Nuevo payload de creación ===
 export interface ChatMessageCreatePayload {
@@ -9,7 +10,7 @@ export interface ChatMessageCreatePayload {
   sender: "user" | "ai";
   project_id: number;
   state: StateMachineState;
-  language?: string;           // el service lo rellenará si no viene
+  language?: Language;           // el service lo rellenará si no viene
   example_samples?: string[];  // opcional
 }
 
@@ -44,11 +45,11 @@ export async function fetchProjectMessages(
 export async function sendMessage(
   payload: ChatMessageCreatePayload
 ): Promise<MessageModel> {
-  const language =
+  const language: Language =
     payload.language ??
     (typeof navigator !== "undefined" && navigator.language
-      ? navigator.language
-      : "es-ES");
+      ? (navigator.language.split("-")[0] as Language)
+      : "es");
 
   const body = { ...payload, language };
 


### PR DESCRIPTION
## Summary
- type App language state with `Language` and pass to components without casts
- update components, models, and service payloads to use `Language` type consistently

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 37 problems, including `@typescript-eslint/no-explicit-any` errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898567cf0c88332a386de738ac86ad0