### PR TITLE
feat: use requirement generation endpoint

### DIFF
--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -15,6 +15,7 @@ import { getTranslations, type Language } from "../i18n";
 import type { MessageModel } from "../models/message-model";
 import { useStateMachine } from "../context/StateMachineContext";
 import type { ChatMessageCreatePayload } from "../services/chat-service";
+import { generateRequirement } from "../services/requirements-service";
 
 interface ChatAreaProps {
   chatMessages: MessageModel[];
@@ -111,6 +112,21 @@ export function ChatArea({
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSend();
+    }
+  };
+
+  const handleGenerateRequirement = async (category: string) => {
+    const examples = parseExamples(exampleRequirementsText);
+
+    try {
+      await generateRequirement(
+        projectId,
+        category,
+        language,
+        examples.length > 0 ? examples : undefined
+      );
+    } catch (err) {
+      console.error(err);
     }
   };
 
@@ -277,7 +293,7 @@ export function ChatArea({
                         color="primary"
                         size="small"
                         disabled={loading}
-                        onClick={() => console.log(t.chatStallAddFunctional)}
+                        onClick={() => handleGenerateRequirement("functional")}
                         sx={{ whiteSpace: "nowrap" }}
                       >
                         {t.chatStallAddFunctional}
@@ -300,10 +316,10 @@ export function ChatArea({
                         onClose={handleCloseMenu}
                         MenuListProps={{ dense: true }}
                       >
-                        <MenuItem onClick={() => { console.log("performance"); handleCloseMenu(); }}>{t.category.performance}</MenuItem>
-                        <MenuItem onClick={() => { console.log("usability"); handleCloseMenu(); }}>{t.category.usability}</MenuItem>
-                        <MenuItem onClick={() => { console.log("security"); handleCloseMenu(); }}>{t.category.security}</MenuItem>
-                        <MenuItem onClick={() => { console.log("technical"); handleCloseMenu(); }}>{t.category.technical}</MenuItem>
+                        <MenuItem onClick={async () => { await handleGenerateRequirement("performance"); handleCloseMenu(); }}>{t.category.performance}</MenuItem>
+                        <MenuItem onClick={async () => { await handleGenerateRequirement("usability"); handleCloseMenu(); }}>{t.category.usability}</MenuItem>
+                        <MenuItem onClick={async () => { await handleGenerateRequirement("security"); handleCloseMenu(); }}>{t.category.security}</MenuItem>
+                        <MenuItem onClick={async () => { await handleGenerateRequirement("technical"); handleCloseMenu(); }}>{t.category.technical}</MenuItem>
                       </Menu>
                     </Stack>
                   </Box>

--- a/src/services/requirements-service.ts
+++ b/src/services/requirements-service.ts
@@ -1,6 +1,7 @@
 // services/requirements-service.ts
 import { api } from "./api";
 import type { RequirementModel } from "../models/requirements-model";
+import type { Language } from "../i18n";
 
 function mapBackendToRequirement(data: any): RequirementModel {
   return {
@@ -67,4 +68,28 @@ export async function updateRequirement(
 // DELETE requisito
 export async function deleteRequirement(requirementId: string): Promise<void> {
   await api.delete(`/requirements/${requirementId}`);
+}
+
+// POST generar requisito mediante IA
+export async function generateRequirement(
+  projectId: number,
+  category: string,
+  language: Language,
+  exampleSamples?: string[]
+): Promise<any> {
+  const payload: Record<string, any> = {
+    project_id: projectId,
+    category,
+    language,
+  };
+
+  if (exampleSamples && exampleSamples.length > 0) {
+    payload.example_samples = exampleSamples;
+  }
+
+  const { data } = await api.post(`/requirements/generate`, payload, {
+    headers: { "Content-Type": "application/json" },
+  });
+
+  return data;
 }


### PR DESCRIPTION
## Summary
- call requirement generation endpoint with selected category
- add requirement generation service

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 39 errors, 1 warning)


------
https://chatgpt.com/codex/tasks/task_e_68987745fd008332b731f04bb4cdd947