### PR TITLE
Verify access token before storing

### DIFF
--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -39,6 +39,10 @@ export async function login({
     headers: { "Content-Type": "application/x-www-form-urlencoded" }
   });
 
+  if (!data || !data.access_token) {
+    throw new Error("Token de acceso no recibido");
+  }
+
   localStorage.setItem("access_token", data.access_token);
   return data;
 }


### PR DESCRIPTION
## Summary
- Ensure login handler validates presence of access token before saving
- Throw explicit error when token is missing so UI can show a message

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 38 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6898797816548332b2f6db9fe9269393