### PR TITLE
feat: improve register flow and error handling

### DIFF
--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -1,5 +1,6 @@
 // services/auth-service.ts
 import { api } from "./api";
+import type { AxiosError } from "axios";
 
 // Registra un usuario nuevo
 export async function register({
@@ -13,13 +14,21 @@ export async function register({
   password: string;
   avatar?: string | null;
 }) {
-  const { data } = await api.post("/auth/register", {
-    username,
-    email,
-    password,
-    avatar
-  });
-  return data;
+  try {
+    await api.post("/auth/register", {
+      username,
+      email,
+      password,
+      avatar
+    });
+
+    const loginData = await login({ username, password });
+    return { message: "Registro exitoso", ...loginData };
+  } catch (error) {
+    const err = error as AxiosError<{ detail?: string }>;
+    const message = err.response?.data?.detail ?? err.message ?? "Error al registrar usuario";
+    throw new Error(message);
+  }
 }
 
 // Login (OAuth2 password flow)
@@ -30,17 +39,23 @@ export async function login({
   username: string;
   password: string;
 }) {
-  const params = new URLSearchParams();
-  params.append("username", username);
-  params.append("password", password);
+  try {
+    const params = new URLSearchParams();
+    params.append("username", username);
+    params.append("password", password);
 
-  // grant_type, client_id y scope pueden omitirse si no los requiere FastAPI
-  const { data } = await api.post("/auth/login", params.toString(), {
-    headers: { "Content-Type": "application/x-www-form-urlencoded" }
-  });
+    // grant_type, client_id y scope pueden omitirse si no los requiere FastAPI
+    const { data } = await api.post("/auth/login", params.toString(), {
+      headers: { "Content-Type": "application/x-www-form-urlencoded" }
+    });
 
-  localStorage.setItem("access_token", data.access_token);
-  return data;
+    localStorage.setItem("access_token", data.access_token);
+    return data;
+  } catch (error) {
+    const err = error as AxiosError<{ detail?: string }>;
+    const message = err.response?.data?.detail ?? err.message ?? "Error al iniciar sesión";
+    throw new Error(message);
+  }
 }
 
 // Devuelve el usuario autenticado


### PR DESCRIPTION
## Summary
- auto-login user after successful registration
- surface descriptive API error messages for register and login

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in other files)*
- `npx eslint src/services/auth-service.ts`


------
https://chatgpt.com/codex/tasks/task_e_68987979d3388332b743ae73f246b8f0