### PR TITLE
feat(auth): dispatch auth change events

### DIFF
--- a/src/router/RootRouter.tsx
+++ b/src/router/RootRouter.tsx
@@ -16,13 +16,15 @@ export function RootRouter(props: RootRouterProps) {
   );
 
   useEffect(() => {
-    const handleStorage = () => {
+    const handleAuthChanged = () => {
       setToken(localStorage.getItem("access_token"));
     };
 
-    window.addEventListener("storage", handleStorage);
+    window.addEventListener("storage", handleAuthChanged);
+    window.addEventListener("auth:changed", handleAuthChanged);
     return () => {
-      window.removeEventListener("storage", handleStorage);
+      window.removeEventListener("storage", handleAuthChanged);
+      window.removeEventListener("auth:changed", handleAuthChanged);
     };
   }, []);
 

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -50,6 +50,7 @@ export async function login({
     });
 
     localStorage.setItem("access_token", data.access_token);
+    window.dispatchEvent(new CustomEvent("auth:changed"));
     return data;
   } catch (error) {
     const err = error as AxiosError<{ detail?: string }>;
@@ -68,6 +69,7 @@ export async function getMe() {
 export function logout() {
   try {
     localStorage.removeItem("access_token");
+    window.dispatchEvent(new CustomEvent("auth:changed"));
   } catch {
     // ignorar si no existe
   }


### PR DESCRIPTION
## Summary
- listen for custom auth:changed events to sync token state
- dispatch auth:changed after login and logout to keep router in sync

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 42 problems (41 errors, 1 warning))*

------
https://chatgpt.com/codex/tasks/task_e_68987cb3e5d883328de57908dbfae829