### PR TITLE
Handle missing access token from auth service

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -40,12 +40,7 @@ export function LoginPage() {
         if (!username || !password) { setError(t.errorUserPasswordRequired); return; }
         await login({ username, password });
         setError("");
-        const token = localStorage.getItem("access_token");
-        if (token) {
-          navigate("/");
-        } else {
-          setError(t.errorMissingToken ?? "Missing access token");
-        }
+        navigate("/");
       }
     } catch (err: any) {
       if (axios.isAxiosError(err)) {

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -49,9 +49,14 @@ export async function login({
       headers: { "Content-Type": "application/x-www-form-urlencoded" }
     });
 
-    localStorage.setItem("access_token", data.access_token);
+    const token = typeof data?.access_token === "string" ? data.access_token.trim() : "";
+    if (!token) {
+      throw new Error("Token no recibido");
+    }
+
+    localStorage.setItem("access_token", token);
     window.dispatchEvent(new CustomEvent("auth:changed"));
-    return data;
+    return { ...data, access_token: token };
   } catch (error) {
     const err = error as AxiosError<{ detail?: string }>;
     const message = err.response?.data?.detail ?? err.message ?? "Error al iniciar sesión";


### PR DESCRIPTION
## Summary
- Validate that login responses include a non-empty access token before storing it
- Simplify login page flow to navigate once login succeeds and surface service errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any/unused vars in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68987ed41a4083329eaa812e9128e25a