### PR TITLE
Handle auth token expiration events

### DIFF
--- a/src/router/RootRouter.tsx
+++ b/src/router/RootRouter.tsx
@@ -22,9 +22,11 @@ export function RootRouter(props: RootRouterProps) {
 
     window.addEventListener("storage", handleAuthChanged);
     window.addEventListener("auth:changed", handleAuthChanged);
+    window.addEventListener("auth:expired", handleAuthChanged);
     return () => {
       window.removeEventListener("storage", handleAuthChanged);
       window.removeEventListener("auth:changed", handleAuthChanged);
+      window.removeEventListener("auth:expired", handleAuthChanged);
     };
   }, []);
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -17,8 +17,11 @@ api.interceptors.response.use(
     // Si el backend devuelve 401/403 => sesión expirada o inválida
     if (error?.response?.status === 401 || error?.response?.status === 403) {
       // Limpia token y avisa a la App
-      try { localStorage.removeItem("access_token"); } catch {}
+      try {
+        localStorage.removeItem("access_token");
+      } catch {}
       window.dispatchEvent(new CustomEvent("auth:expired"));
+      window.dispatchEvent(new CustomEvent("auth:changed"));
     }
     return Promise.reject(error);
   }


### PR DESCRIPTION
## Summary
- listen for `auth:expired` events in the root router
- notify auth changes when API removes the token

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68987ed529088332801b1f498fccc65a