### PR TITLE
Ensure backdrop shows when generating requirements and remove duplicate analyze button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { fetchProjectMessages, sendMessage, type ChatMessageCreatePayload } from
 import type { MessageModel } from "./models/message-model";
 import { CircularProgress, Typography, Backdrop } from "@mui/material";
 import { addStateMachineEntry } from "./services/state-machine-service";
+import { generateRequirement } from "./services/requirements-service";
 
 interface AppProps {
   isDarkMode: boolean;
@@ -192,6 +193,29 @@ export default function App({ isDarkMode, onToggleDarkMode }: AppProps) {
     }
   };
 
+  // Handler para generar requisito con IA
+  const handleGenerateRequirement = async (
+    category: string,
+    examples?: string[]
+  ) => {
+    if (!activeProject?.id) return;
+    setLoadingChat(true);
+    setErrorChat(null);
+    try {
+      await generateRequirement(
+        activeProject.id,
+        category,
+        language,
+        examples && examples.length > 0 ? examples : undefined
+      );
+      await reloadMessages();
+    } catch (e) {
+      setErrorChat(t.errorCreateRequirement);
+    } finally {
+      setLoadingChat(false);
+    }
+  };
+
   // Handler para crear nuevo proyecto desde SideMenu
   const handleProjectCreated = async (name: string, description: string) => {
     await createProject({ name, description });
@@ -297,6 +321,7 @@ export default function App({ isDarkMode, onToggleDarkMode }: AppProps) {
                       error={errorChat}
                       onSendMessage={handleSendMessage}
                       onGenerateRequirements={handleAnalyzeWithAI}
+                      onAddRequirement={handleGenerateRequirement}
                       showFiles={showFiles}
                       collapsed={isChatCollapsed}
                       onToggleCollapse={() => setIsChatCollapsed((c) => !c)}

--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -15,7 +15,6 @@ import { getTranslations, type Language } from "../i18n";
 import type { MessageModel } from "../models/message-model";
 import { useStateMachine } from "../context/StateMachineContext";
 import type { ChatMessageCreatePayload } from "../services/chat-service";
-import { generateRequirement } from "../services/requirements-service";
 
 interface ChatAreaProps {
   chatMessages: MessageModel[];
@@ -23,6 +22,7 @@ interface ChatAreaProps {
   error?: string | null;
   onSendMessage: (msg: ChatMessageCreatePayload, projectId: number) => Promise<void>;
   onGenerateRequirements: () => void;
+  onAddRequirement: (category: string, examples?: string[]) => Promise<void>;
   showFiles: boolean;
   collapsed: boolean;
   onToggleCollapse: () => void;
@@ -37,6 +37,7 @@ export function ChatArea({
   error,
   onSendMessage,
   onGenerateRequirements,
+  onAddRequirement,
   showFiles,
   collapsed,
   onToggleCollapse,
@@ -119,12 +120,7 @@ export function ChatArea({
     const examples = parseExamples(exampleRequirementsText);
 
     try {
-      await generateRequirement(
-        projectId,
-        category,
-        language,
-        examples.length > 0 ? examples : undefined
-      );
+      await onAddRequirement(category, examples.length > 0 ? examples : undefined);
     } catch (err) {
       console.error(err);
     }
@@ -262,16 +258,6 @@ export function ChatArea({
                     disabled={loading}
                   />
                   <Stack spacing={1}>
-                    <Button
-                      variant="outlined"
-                      color="primary"
-                      onClick={onGenerateRequirements}
-                      title={t.analyzeWithAI}
-                      size="small"
-                      disabled={loading}
-                    >
-                      <SparklesIcon fontSize="small" />
-                    </Button>
                     <Button
                       variant="contained"
                       color="primary"


### PR DESCRIPTION
## Summary
- trigger global loading backdrop when generating requirements from chat
- remove redundant "Analizar con IA" icon button above send conversation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68988a19daa0833294c4d338a5d502b6