### PR TITLE
Cerrar menú de requisitos no funcionales tras seleccionar opción

### DIFF
--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -302,10 +302,10 @@ export function ChatArea({
                         onClose={handleCloseMenu}
                         MenuListProps={{ dense: true }}
                       >
-                        <MenuItem onClick={async () => { await handleGenerateRequirement("performance"); handleCloseMenu(); }}>{t.category.performance}</MenuItem>
-                        <MenuItem onClick={async () => { await handleGenerateRequirement("usability"); handleCloseMenu(); }}>{t.category.usability}</MenuItem>
-                        <MenuItem onClick={async () => { await handleGenerateRequirement("security"); handleCloseMenu(); }}>{t.category.security}</MenuItem>
-                        <MenuItem onClick={async () => { await handleGenerateRequirement("technical"); handleCloseMenu(); }}>{t.category.technical}</MenuItem>
+                        <MenuItem onClick={async () => { handleCloseMenu(); await handleGenerateRequirement("performance"); }}>{t.category.performance}</MenuItem>
+                        <MenuItem onClick={async () => { handleCloseMenu(); await handleGenerateRequirement("usability"); }}>{t.category.usability}</MenuItem>
+                        <MenuItem onClick={async () => { handleCloseMenu(); await handleGenerateRequirement("security"); }}>{t.category.security}</MenuItem>
+                        <MenuItem onClick={async () => { handleCloseMenu(); await handleGenerateRequirement("technical"); }}>{t.category.technical}</MenuItem>
                       </Menu>
                     </Stack>
                   </Box>


### PR DESCRIPTION
## Summary
- Cerrado el menú de requisitos no funcionales inmediatamente al elegir una categoría, evitando que permanezca sobre el backdrop de carga.

## Testing
- `npm test` (falla: Missing script "test")
- `npm run lint` (errores de lint existentes: no-explicit-any, no-unused-vars, no-require-imports)


------
https://chatgpt.com/codex/tasks/task_e_68988d5c3c3883328d4b3ef20a570457