### PR TITLE
feat: connect settings sections to auth endpoints

### DIFF
--- a/src/components/settings/SettingsPreferencesSection.tsx
+++ b/src/components/settings/SettingsPreferencesSection.tsx
@@ -15,6 +15,7 @@ import {
 import SaveIcon from "@mui/icons-material/Save";
 import type { UserModel } from "../../models/user-model";
 import { getTranslations, type Language } from "../../i18n";
+import { api } from "../../services/api";
 
 interface SettingsPreferencesSectionProps {
   user: UserModel;
@@ -40,12 +41,23 @@ export function SettingsPreferencesSection({ user, onUpdate, language, onLanguag
   const handleSave = async () => {
     if (!onUpdate) return;
     setIsSaving(true);
-    await Promise.resolve(); // simula async
-    onUpdate({
-      ...user,
-      preferences: { language, theme, timezone, notifications }
-    });
-    setIsSaving(false);
+    const updatedPreferences = { language, theme, timezone, notifications };
+    try {
+      await api.put("/auth/preferences", {
+        theme,
+        notifications,
+        language,
+        timezone
+      });
+      onUpdate({
+        ...user,
+        preferences: updatedPreferences
+      });
+    } catch (error) {
+      console.error("Error updating preferences", error);
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   return (

--- a/src/components/settings/SettingsUserSection.tsx
+++ b/src/components/settings/SettingsUserSection.tsx
@@ -11,6 +11,7 @@ import {
 import UploadIcon from "@mui/icons-material/Upload";
 import SaveIcon from "@mui/icons-material/Save";
 import { getTranslations, type Language } from "../../i18n";
+import { api } from "../../services/api";
 
 interface SettingsUserSectionProps {
   user: UserModel;
@@ -47,17 +48,24 @@ export function SettingsUserSection({ user, onUpdate, language }: SettingsUserSe
   const handleSave = async () => {
     if (!onUpdate) return;
     setIsSaving(true);
-    // Puedes hacer aquí un fetch/axios PUT real al backend si quieres
-    // Por ahora solo mock:
     const updatedUser: UserModel = {
       ...user,
       username,
       email,
       avatar
     };
-    await Promise.resolve(); // Mock async
-    onUpdate(updatedUser);
-    setIsSaving(false);
+    try {
+      await api.put("/auth/me", {
+        username,
+        email,
+        avatar
+      });
+      onUpdate(updatedUser);
+    } catch (error) {
+      console.error("Error updating user", error);
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- connect SettingsUserSection save button with PUT /auth/me
- send SettingsPreferencesSection updates to PUT /auth/preferences

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, no-unused-vars, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_6898aaa97bb48332b1b4eeef228b1647