### PR TITLE
feat: apply user preferences on login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,6 +101,28 @@ export default function App({ isDarkMode, onToggleDarkMode }: AppProps) {
     // eslint-disable-next-line
   }, []);
 
+  // Ajusta idioma y tema según preferencias del usuario al iniciar sesión
+  useEffect(() => {
+    if (user?.preferences) {
+      // Ajustar idioma
+      setLanguage(user.preferences.language);
+
+      // Determinar modo oscuro deseado
+      let shouldBeDark = isDarkMode;
+      const prefTheme = user.preferences.theme;
+      if (prefTheme === "dark") shouldBeDark = true;
+      else if (prefTheme === "light") shouldBeDark = false;
+      else if (prefTheme === "auto") {
+        shouldBeDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      }
+
+      // Cambiar tema si es necesario
+      if (shouldBeDark !== isDarkMode) {
+        onToggleDarkMode();
+      }
+    }
+  }, [user, isDarkMode, onToggleDarkMode]);
+
   // Recupera proyectos cuando hay usuario
   useEffect(() => {
     if (user) {


### PR DESCRIPTION
## Summary
- Read user preferences after authentication
- Apply preferred language and theme on login

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898ac932e1c833281b409a4e7c1bd47