### PR TITLE
feat: show confirmation after settings save

### DIFF
--- a/src/components/settings/SettingsPreferencesSection.tsx
+++ b/src/components/settings/SettingsPreferencesSection.tsx
@@ -10,7 +10,9 @@ import {
   MenuItem,
   Switch,
   FormControlLabel,
-  TextField
+  TextField,
+  Snackbar,
+  Alert
 } from "@mui/material";
 import SaveIcon from "@mui/icons-material/Save";
 import type { UserModel } from "../../models/user-model";
@@ -29,6 +31,7 @@ export function SettingsPreferencesSection({ user, onUpdate, language, onLanguag
   const [timezone, setTimezone] = useState(user.preferences.timezone);
   const [notifications, setNotifications] = useState(user.preferences.notifications);
   const [isSaving, setIsSaving] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
   const t = getTranslations(language);
 
   // Comprobar cambios para habilitar botón
@@ -53,6 +56,7 @@ export function SettingsPreferencesSection({ user, onUpdate, language, onLanguag
         ...user,
         preferences: updatedPreferences
       });
+      setShowSuccess(true);
     } catch (error) {
       console.error("Error updating preferences", error);
     } finally {
@@ -124,6 +128,19 @@ export function SettingsPreferencesSection({ user, onUpdate, language, onLanguag
           </Button>
         </Stack>
       </Stack>
+      <Snackbar
+        open={showSuccess}
+        autoHideDuration={3000}
+        onClose={() => setShowSuccess(false)}
+      >
+        <Alert
+          onClose={() => setShowSuccess(false)}
+          severity="success"
+          sx={{ width: "100%" }}
+        >
+          {t.settingsSaved}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/src/components/settings/SettingsUserSection.tsx
+++ b/src/components/settings/SettingsUserSection.tsx
@@ -6,7 +6,9 @@ import {
   Button,
   TextField,
   Stack,
-  Typography
+  Typography,
+  Snackbar,
+  Alert
 } from "@mui/material";
 import UploadIcon from "@mui/icons-material/Upload";
 import SaveIcon from "@mui/icons-material/Save";
@@ -24,6 +26,7 @@ export function SettingsUserSection({ user, onUpdate, language }: SettingsUserSe
   const [email, setEmail] = useState(user.email);
   const [avatar, setAvatar] = useState(user.avatar);
   const [isSaving, setIsSaving] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const t = getTranslations(language);
 
@@ -61,6 +64,7 @@ export function SettingsUserSection({ user, onUpdate, language }: SettingsUserSe
         avatar
       });
       onUpdate(updatedUser);
+      setShowSuccess(true);
     } catch (error) {
       console.error("Error updating user", error);
     } finally {
@@ -118,6 +122,19 @@ export function SettingsUserSection({ user, onUpdate, language }: SettingsUserSe
           {isSaving ? t.settingsUserSaving : t.settingsUserSave}
         </Button>
       </Stack>
+      <Snackbar
+        open={showSuccess}
+        autoHideDuration={3000}
+        onClose={() => setShowSuccess(false)}
+      >
+        <Alert
+          onClose={() => setShowSuccess(false)}
+          severity="success"
+          sx={{ width: "100%" }}
+        >
+          {t.settingsSaved}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -139,6 +139,7 @@ const translations: Record<Language, Translations> = {
     settingsPrefsTimezoneLabel: "Timezone",
     settingsPrefsNotificationsLabel: "Notifications",
     settingsPrefsSave: "Save changes",
+    settingsSaved: "Changes saved",
 
     // Settings - Example Files Section
     settingsFilesTitle: "Example Files",
@@ -300,6 +301,7 @@ const translations: Record<Language, Translations> = {
     settingsPrefsTimezoneLabel: "Zona Horaria",
     settingsPrefsNotificationsLabel: "Notificaciones",
     settingsPrefsSave: "Guardar cambios",
+    settingsSaved: "Cambios guardados",
 
     // Settings - Example Files Section
     settingsFilesTitle: "Archivos de Ejemplo",
@@ -461,6 +463,7 @@ const translations: Record<Language, Translations> = {
     settingsPrefsTimezoneLabel: "Zona Horària",
     settingsPrefsNotificationsLabel: "Notificacions",
     settingsPrefsSave: "Desar canvis",
+    settingsSaved: "Canvis desats",
 
     // Settings - Example Files Section
     settingsFilesTitle: "Fitxers d'Exemple",


### PR DESCRIPTION
## Summary
- show success message after saving user settings or preferences
- add translations for confirmation message in all languages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 43 errors, 1 warning)


------
https://chatgpt.com/codex/tasks/task_e_6898b9b1fae88332b22d7829828f45f8