### PR TITLE
feat: add file service

### DIFF
--- a/src/services/file-service.ts
+++ b/src/services/file-service.ts
@@ -1,0 +1,37 @@
+// services/file-service.ts
+import { api } from "./api";
+
+export interface ConfigFile {
+  id: number;
+  filename: string;
+  [key: string]: unknown;
+}
+
+// Upload a configuration file via FormData
+export async function uploadConfigFile(file: File): Promise<ConfigFile> {
+  const formData = new FormData();
+  formData.append("uploaded_file", file);
+
+  const { data } = await api.post<ConfigFile>("/files/upload", formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+  return data;
+}
+
+// Fetch list of configuration files
+export async function fetchConfigFiles(): Promise<ConfigFile[]> {
+  const { data } = await api.get<ConfigFile[]>("/files/");
+  return data;
+}
+
+// Fetch requirements text for a specific file
+export async function fetchFileRequirements(fileId: number): Promise<string> {
+  const { data } = await api.get<string>(`/files/${fileId}/requirements`);
+  return data;
+}
+
+export default {
+  uploadConfigFile,
+  fetchConfigFiles,
+  fetchFileRequirements,
+};


### PR DESCRIPTION
## Summary
- add file service for uploading config files and retrieving requirements

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run build` *(fails: TS6133 unused variable errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898c586da3c8332ba92d2f6d8a80d9d