### PR TITLE
Handle example file uploads with service

### DIFF
--- a/src/models/user-model.ts
+++ b/src/models/user-model.ts
@@ -22,9 +22,13 @@ export type UserPreferences = {
     timezone: string;
 };
 
+export type ExampleFile = {
+    id: string;
+    name: string;
+}
+
 export type ExampleFiles = {
-    files: string[];
-    filesId?: number[];
+    files: ExampleFile[];
     prefered: string;
     lastUpdated: Date;
 }

--- a/src/services/file-service.ts
+++ b/src/services/file-service.ts
@@ -1,0 +1,15 @@
+// services/file-service.ts
+import { api } from "./api";
+import type { ExampleFile } from "../models/user-model";
+
+// Upload configuration/example file to the backend
+export async function uploadConfigFile(file: File): Promise<ExampleFile> {
+    const formData = new FormData();
+    formData.append("file", file);
+
+    const { data } = await api.post<ExampleFile>("/files/config", formData, {
+        headers: { "Content-Type": "multipart/form-data" },
+    });
+
+    return data;
+}


### PR DESCRIPTION
## Summary
- upload example files using new `uploadConfigFile` service
- store returned file metadata and render real names

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6898c595e8f883329155bca9907c8020