### PR TITLE
feat: load config file examples

### DIFF
--- a/src/services/config-files-service.ts
+++ b/src/services/config-files-service.ts
@@ -1,0 +1,19 @@
+import { api } from "./api";
+
+export interface ConfigFile {
+  id: number;
+  name: string;
+}
+
+// Obtener archivos de configuración subidos para un proyecto
+export async function fetchConfigFiles(projectId: number): Promise<ConfigFile[]> {
+  const { data } = await api.get<ConfigFile[]>(`/config_files/project/${projectId}`);
+  return data;
+}
+
+// Obtener los requisitos de un archivo de configuración
+export async function fetchFileRequirements(fileId: number): Promise<string> {
+  const { data } = await api.get<{ content: string }>(`/config_files/${fileId}/requirements`);
+  if (typeof data === "string") return data;
+  return data.content;
+}


### PR DESCRIPTION
## Summary
- load config files on chat area init and populate select
- fetch selected config file requirements into example text
- add service for config file APIs

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 44 problems, 43 errors, 1 warning)


------
https://chatgpt.com/codex/tasks/task_e_6898c5a0c15c83328d38b148718d1917