### PR TITLE
Fix requirement add buttons by refreshing table after AI generation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ export default function App({ isDarkMode, onToggleDarkMode }: AppProps) {
 
   const [isChatCollapsed, setIsChatCollapsed] = useState(false);
   const [isReqsCollapsed, setIsReqsCollapsed] = useState(false);
+  const [requirementsReloadTrigger, setRequirementsReloadTrigger] = useState(0);
 
   const themePrefRef = useRef<string | null>(null);
 
@@ -241,6 +242,8 @@ export default function App({ isDarkMode, onToggleDarkMode }: AppProps) {
         examples && examples.length > 0 ? examples : undefined
       );
       await reloadMessages();
+      // Trigger reload of requirements table to include the new requirement
+      setRequirementsReloadTrigger((v) => v + 1);
     } catch {
       setErrorChat(t.errorCreateRequirement);
     } finally {
@@ -372,6 +375,7 @@ export default function App({ isDarkMode, onToggleDarkMode }: AppProps) {
                         language={language}
                         ownerId={user.id}
                         projectId={activeProject.id}
+                        reloadTrigger={requirementsReloadTrigger}
                       />
                     </Box>
                   )}

--- a/src/components/RequirementsTable.tsx
+++ b/src/components/RequirementsTable.tsx
@@ -34,6 +34,12 @@ interface RequirementsTableProps {
   language: Language;
   projectId: number;
   ownerId: number;
+  /**
+   * When this value changes the table will reload requirements from the backend.
+   * It allows parent components to trigger a refresh after external actions
+   * such as generating a requirement from the chat area.
+   */
+  reloadTrigger?: number;
 }
 
 const statusColors: Record<RequirementModel['status'], 'default' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning'> = {
@@ -50,7 +56,14 @@ const priorityColors: Record<RequirementModel['priority'], 'default' | 'primary'
   wont: "default"
 };
 
-export function RequirementsTable({ collapsed, onToggleCollapse, language, projectId, ownerId }: RequirementsTableProps) {
+export function RequirementsTable({
+  collapsed,
+  onToggleCollapse,
+  language,
+  projectId,
+  ownerId,
+  reloadTrigger = 0,
+}: RequirementsTableProps) {
   const t = getTranslations(language);
   const [requirements, setRequirements] = useState<RequirementModel[]>([]);
   const [loading, setLoading] = useState(false);
@@ -79,13 +92,14 @@ export function RequirementsTable({ collapsed, onToggleCollapse, language, proje
   };
 
   // Cargar requisitos del backend cuando cambia el proyecto
+  // o cuando un componente padre indica que se deben recargar
   useEffect(() => {
     setLoading(true);
     fetchProjectRequirements(projectId)
       .then(setRequirements)
       .catch(() => setError(t.errorLoadRequirements))
       .finally(() => setLoading(false));
-  }, [projectId]);
+  }, [projectId, reloadTrigger, t.errorLoadRequirements]);
 
   // Filtrado + ordenación de requisitos
   const filteredRequirements = useMemo(() => {


### PR DESCRIPTION
## Summary
- Allow RequirementsTable to reload from parent components
- Refresh requirements table after generating a requirement via chat

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any... etc.)

------
https://chatgpt.com/codex/tasks/task_e_6898d0a256a48332a1ed763b8e3d42a8