### PR TITLE
feat: enforce API base URL configuration

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,8 +1,13 @@
 // services/api.ts
 import axios from "axios";
 
+const baseURL = import.meta.env.VITE_API_BASE_URL;
+if (!baseURL) {
+  throw new Error("VITE_API_BASE_URL is not defined");
+}
+
 export const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || "http://localhost:8000",
+  baseURL,
 });
 
 api.interceptors.request.use((config) => {


### PR DESCRIPTION
## Summary
- ensure API base URL is provided and remove fallback

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 33 errors, 0 warnings)
- `VITE_API_BASE_URL=http://localhost:8000 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898dfe29e9c833287a5100a6cc5d9cd