### PR TITLE
docs: reference VITE_API_BASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Este repositorio contiene la interfaz web del **Gestor de Requisitos**, una apli
    cp .env.example .env
    ```
 
-   - Establece la URL del backend, por ejemplo:
+   - Establece la URL base del backend, por ejemplo:
 
      ```env
-     VITE_API_URL=http://localhost:8000
+     VITE_API_BASE_URL=http://localhost:8000
      ```
 
 4. Inicia la aplicación en modo desarrollo:


### PR DESCRIPTION
## Summary
- reference `VITE_API_BASE_URL` instead of `VITE_API_URL`
- ensure repository consistently uses `VITE_API_BASE_URL`

## Testing
- `npx prettier README.md --write`
- `pnpm lint` *(fails: 33 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898dfe2c7648332bc757786713cbcd4