### PR TITLE
chore: add example environment file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Base URL for API requests made by the Vite application
+VITE_API_BASE_URL=https://api.example.com
+
+# Environment type for Vite (e.g., development, staging, production)
+VITE_ENV=development


### PR DESCRIPTION
## Summary
- add `.env.example` file with placeholders for `VITE_API_BASE_URL` and `VITE_ENV`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 33 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898dfe436b08332bdc42cebb318d233