### PR TITLE
docs: document API base URL env variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 VITE_ENV=debug
+VITE_API_BASE_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Este repositorio contiene la interfaz web del **Gestor de Requisitos**, una apli
    cp .env.example .env
    ```
 
-   - Establece la URL del backend, por ejemplo:
+   - Establece la URL base del backend, por ejemplo:
 
      ```env
-     VITE_API_URL=http://localhost:8000
+     VITE_API_BASE_URL=http://localhost:8000
      ```
 
 4. Inicia la aplicación en modo desarrollo:


### PR DESCRIPTION
## Summary
- add VITE_API_BASE_URL to .env for backend base URL
- note API base URL env var in developer onboarding notes

## Testing
- `npx prettier README.md --check`
- `pnpm lint` *(fails: Unexpected any in services and unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_6898dfe61d1883328b65aa3c79f86ee1