### PR TITLE
Add generic error translation and use in login page

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -9,6 +9,7 @@ const translations: Record<Language, Translations> = {
     // App
     processingResponse: "Your response is being processed by the AI.",
     processingWait: "It may take up to a minute. Please wait...",
+    genericError: "Error",
     errorLoadMessages: "Failed to load messages.",
     errorSendMessage: "Failed to send the message.",
     errorAnalyzeAI: "Failed to analyze with AI.",
@@ -171,6 +172,7 @@ const translations: Record<Language, Translations> = {
     // App
     processingResponse: "Su respuesta está siendo procesada por la IA.",
     processingWait: "Podría tardar hasta un minuto. Por favor, espere...",
+    genericError: "Error",
     errorLoadMessages: "No se pudieron cargar los mensajes.",
     errorSendMessage: "No se pudo enviar el mensaje.",
     errorAnalyzeAI: "No se pudo analizar con IA.",
@@ -333,6 +335,7 @@ const translations: Record<Language, Translations> = {
     // App
     processingResponse: "La teva resposta està sent processada per la IA.",
     processingWait: "Podria trigar fins a un minut. Si us plau, espera...",
+    genericError: "Error",
     errorLoadMessages: "No s'han pogut carregar els missatges.",
     errorSendMessage: "No s'ha pogut enviar el missatge.",
     errorAnalyzeAI: "No s'ha pogut analitzar amb IA.",

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -57,9 +57,9 @@ export function LoginPage() {
             message = data.message;
           }
         }
-        setError(message || "Error");
+        setError(message || t.genericError);
       } else {
-        setError(err.message || "Error");
+        setError(err.message || t.genericError);
       }
     }
   };


### PR DESCRIPTION
## Summary
- add `genericError` translation in English, Spanish and Catalan
- use shared translation for login page error messages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint found 25 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898e5c645188332a33fc45fc3e97c9a