### PR TITLE
feat: internationalize auth service messages

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -166,6 +166,10 @@ const translations: Record<Language, Translations> = {
     registerLink: "Register",
     hasAccountPrompt: "Already have an account?",
     loginLink: "Login",
+    registerSuccess: "Registration successful",
+    errorRegisterUser: "Error registering user",
+    tokenNotReceived: "Token not received",
+    errorLogin: "Error logging in",
   },
   es: {
     // App
@@ -328,6 +332,10 @@ const translations: Record<Language, Translations> = {
     registerLink: "Regístrate",
     hasAccountPrompt: "¿Ya tienes cuenta?",
     loginLink: "Inicia sesión",
+    registerSuccess: "Registro exitoso",
+    errorRegisterUser: "Error al registrar usuario",
+    tokenNotReceived: "Token no recibido",
+    errorLogin: "Error al iniciar sesión",
   },
   ca: {
     // App
@@ -490,6 +498,10 @@ const translations: Record<Language, Translations> = {
     registerLink: "Registra't",
     hasAccountPrompt: "Ja tens compte?",
     loginLink: "Inicia sessió",
+    registerSuccess: "Registre amb èxit",
+    errorRegisterUser: "Error en registrar l'usuari",
+    tokenNotReceived: "Token no rebut",
+    errorLogin: "Error en iniciar sessió",
   },
 };
 

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -1,6 +1,7 @@
 // services/auth-service.ts
 import { api } from "./api";
 import type { AxiosError } from "axios";
+import { getTranslations, type Language } from "../i18n";
 
 // Registra un usuario nuevo
 export async function register({
@@ -14,6 +15,11 @@ export async function register({
   password: string;
   avatar?: string | null;
 }) {
+  const language: Language =
+    typeof navigator !== "undefined" && navigator.language
+      ? (navigator.language.split("-")[0] as Language)
+      : "es";
+  const t = getTranslations(language);
   try {
     await api.post("/auth/register", {
       username,
@@ -23,10 +29,10 @@ export async function register({
     });
 
     const loginData = await login({ username, password });
-    return { message: "Registro exitoso", ...loginData };
+    return { message: t.registerSuccess, ...loginData };
   } catch (error) {
     const err = error as AxiosError<{ detail?: string }>;
-    const message = err.response?.data?.detail ?? err.message ?? "Error al registrar usuario";
+    const message = err.response?.data?.detail ?? err.message ?? t.errorRegisterUser;
     throw new Error(message);
   }
 }
@@ -39,6 +45,11 @@ export async function login({
   username: string;
   password: string;
 }) {
+  const language: Language =
+    typeof navigator !== "undefined" && navigator.language
+      ? (navigator.language.split("-")[0] as Language)
+      : "es";
+  const t = getTranslations(language);
   try {
     const params = new URLSearchParams();
     params.append("username", username);
@@ -51,7 +62,7 @@ export async function login({
 
     const token = typeof data?.access_token === "string" ? data.access_token.trim() : "";
     if (!token) {
-      throw new Error("Token no recibido");
+      throw new Error(t.tokenNotReceived);
     }
 
     localStorage.setItem("access_token", token);
@@ -59,7 +70,7 @@ export async function login({
     return { ...data, access_token: token };
   } catch (error) {
     const err = error as AxiosError<{ detail?: string }>;
-    const message = err.response?.data?.detail ?? err.message ?? "Error al iniciar sesión";
+    const message = err.response?.data?.detail ?? err.message ?? t.errorLogin;
     throw new Error(message);
   }
 }


### PR DESCRIPTION
## Summary
- add translation entries for auth success and error messages
- use current language translations in auth service instead of hardcoded strings

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 25 errors)
- `npx eslint src/services/auth-service.ts src/i18n.ts` (fails: Unexpected any in src/i18n.ts)


------
https://chatgpt.com/codex/tasks/task_e_6898e5cc07b8833281deca768e813730