### PR TITLE
feat: add translation for state machine context

### DIFF
--- a/src/context/StateMachineContext.tsx
+++ b/src/context/StateMachineContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useState } from "react";
+import { getTranslations, type Language } from "../i18n";
 
 // Define los estados posibles
 export type StateMachineState = "init" | "software_questions" | "new_requisites" | "analyze_requisites" | "stall";
@@ -51,6 +52,13 @@ export function StateMachineProvider({ children }: { children: React.ReactNode }
 // Hook para acceder al contexto
 export function useStateMachine() {
   const ctx = useContext(StateMachineContext);
-  if (!ctx) throw new Error("useStateMachine debe usarse dentro de StateMachineProvider");
+  if (!ctx) {
+    const language: Language =
+      typeof navigator !== "undefined" && navigator.language
+        ? (navigator.language.split("-")[0] as Language)
+        : "es";
+    const t = getTranslations(language);
+    throw new Error(t.errorUseStateMachine);
+  }
   return ctx;
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -12,6 +12,7 @@ const translations: Record<Language, Translations> = {
     errorLoadMessages: "Failed to load messages.",
     errorSendMessage: "Failed to send the message.",
     errorAnalyzeAI: "Failed to analyze with AI.",
+    errorUseStateMachine: "useStateMachine must be used within StateMachineProvider",
 
     // ChatArea
     chatTitle: "AI Assistant",
@@ -174,6 +175,7 @@ const translations: Record<Language, Translations> = {
     errorLoadMessages: "No se pudieron cargar los mensajes.",
     errorSendMessage: "No se pudo enviar el mensaje.",
     errorAnalyzeAI: "No se pudo analizar con IA.",
+    errorUseStateMachine: "useStateMachine debe usarse dentro de StateMachineProvider",
 
     // ChatArea
     chatTitle: "Asistente IA",
@@ -335,7 +337,8 @@ const translations: Record<Language, Translations> = {
     processingWait: "Podria trigar fins a un minut. Si us plau, espera...",
     errorLoadMessages: "No s'han pogut carregar els missatges.",
     errorSendMessage: "No s'ha pogut enviar el missatge.",
-    errorAnalyzeAI: "No s'ha pogut analitzar amb IA.",
+   errorAnalyzeAI: "No s'ha pogut analitzar amb IA.",
+    errorUseStateMachine: "useStateMachine s'ha d'utilitzar dins de StateMachineProvider",
 
     // ChatArea
     chatTitle: "Assistent IA",


### PR DESCRIPTION
## Summary
- add errorUseStateMachine translations in English, Spanish, and Catalan
- localize StateMachineContext error using the new translation key

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 25 errors, 0 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6898e5d767c88332a1e4048177a16649