### PR TITLE
Mock navigator language in auth tests

### DIFF
--- a/src/services/__tests__/auth-service.test.ts
+++ b/src/services/__tests__/auth-service.test.ts
@@ -31,6 +31,7 @@ describe("auth-service", () => {
       value: localStorageMock,
       configurable: true
     });
+    vi.spyOn(window.navigator, "language", "get").mockReturnValue("es-ES");
     vi.clearAllMocks();
   });
 


### PR DESCRIPTION
## Summary
- Ensure auth service tests run with Spanish locale by stubbing `window.navigator.language` to `es-ES`
- Keep cleanup via `vi.restoreAllMocks`

## Testing
- `npm test src/services/__tests__/auth-service.test.ts`
- `npm test` *(fails: StateMachineContext.test.tsx > throws if useStateMachine is used outside of provider)*

------
https://chatgpt.com/codex/tasks/task_e_68991079e86c8332a7647380247c7a39