### PR TITLE
Reload translation on RequirementsTable reload

### DIFF
--- a/src/components/RequirementsTable.tsx
+++ b/src/components/RequirementsTable.tsx
@@ -107,11 +107,12 @@ export function RequirementsTable({
   // o cuando un componente padre indica que se deben recargar
   useEffect(() => {
     setLoading(true);
+    const errorText = getTranslations(language).errorLoadRequirements;
     fetchProjectRequirements(projectId)
       .then(setRequirements)
-      .catch(() => setError(t.errorLoadRequirements))
+      .catch(() => setError(errorText))
       .finally(() => setLoading(false));
-  }, [projectId, reloadTrigger, t.errorLoadRequirements]);
+  }, [projectId, reloadTrigger, language]);
 
   // Filtrado + ordenación de requisitos
   const filteredRequirements = useMemo(() => {


### PR DESCRIPTION
## Summary
- Refresh error translation in RequirementsTable effect
- Trigger requirements reload when project, reload trigger, or language changes

## Testing
- `npx vitest run src/components/__tests__/RequirementsTable.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6899107f6fd48332ab0705a601bfa5b4