### PR TITLE
test: stub navigator language in StateMachineContext tests

### DIFF
--- a/src/context/__tests__/StateMachineContext.test.tsx
+++ b/src/context/__tests__/StateMachineContext.test.tsx
@@ -24,12 +24,13 @@ describe('StateMachineContext', () => {
   beforeEach(() => {
     vi.resetModules();
     originalEnv = import.meta.env.VITE_ENV;
+    vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('es-ES');
   });
 
   afterEach(() => {
     import.meta.env.VITE_ENV = originalEnv;
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
-    vi.clearAllMocks();
   });
 
   it('initializes with new_requisites and persists state in debug mode', async () => {


### PR DESCRIPTION
## Summary
- Force `navigator.language` to Spanish before importing `useStateMachine`
- Restore all mocks after each test

## Testing
- `npm test src/context/__tests__/StateMachineContext.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6899107ada1483328657ba7bda0fdbca