### PR TITLE
feat: export requirements from stall mode

### DIFF
--- a/src/components/__tests__/RequirementsTable.test.tsx
+++ b/src/components/__tests__/RequirementsTable.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { RequirementsTable } from "../RequirementsTable";
 import type { RequirementModel } from "../../models/requirements-model";
+import { StateMachineProvider } from "../../context/StateMachineContext";
 
 vi.mock("../../services/requirements-service", () => ({
   fetchProjectRequirements: vi.fn(),
@@ -50,13 +51,15 @@ const requirements: RequirementModel[] = [
 
 function renderTable() {
   return render(
-    <RequirementsTable
-      collapsed={false}
-      onToggleCollapse={() => {}}
-      language="en"
-      projectId={1}
-      ownerId={1}
-    />
+    <StateMachineProvider>
+      <RequirementsTable
+        collapsed={false}
+        onToggleCollapse={() => {}}
+        language="en"
+        projectId={1}
+        ownerId={1}
+      />
+    </StateMachineProvider>
   );
 }
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -39,6 +39,7 @@ const translations: Record<Language, Translations> = {
     // RequirementsTable
     requirementsTableTitle: "Requirements Table",
     addRequirement: "Add Requirement",
+    exportRequirements: "Export Requirements",
     newRequirementDescription: "New requirement",
     searchLabel: "Search",
     searchPlaceholder: "Search by description or ID (e.g., REQ-FN-001)...",
@@ -208,6 +209,7 @@ const translations: Record<Language, Translations> = {
     // RequirementsTable
     requirementsTableTitle: "Tabla de Requisitos",
     addRequirement: "Añadir Requisito",
+    exportRequirements: "Exportar Requisitos",
     newRequirementDescription: "Nuevo requisito",
     searchLabel: "Buscar",
     searchPlaceholder: "Buscar por descripción o ID (ej: REQ-FN-001)...",
@@ -378,6 +380,7 @@ const translations: Record<Language, Translations> = {
     // RequirementsTable
     requirementsTableTitle: "Taula de Requisits",
     addRequirement: "Afegir Requisit",
+    exportRequirements: "Exportar Requisits",
     newRequirementDescription: "Nou requisit",
     searchLabel: "Cercar",
     searchPlaceholder: "Cerca per descripció o ID (ex: REQ-FN-001)...",


### PR DESCRIPTION
## Summary
- allow exporting requirements to a text file when in stall mode
- add translations and tests for stall-only export feature

## Testing
- `npm test`
- `npm run lint` *(fails: "36 problems (36 errors, 0 warnings)")*


------
https://chatgpt.com/codex/tasks/task_e_6899a43d354c8332bc6352c41c5bbeb9