### PR TITLE
Add FastAPI backend skeleton

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,19 @@
+# Gestor de Requisitos – Backend
+
+Esqueleto inicial de la API REST descrita por el frontend. Está construido con [FastAPI](https://fastapi.tiangolo.com/) y agrupa los endpoints en routers modulares.
+
+## Instalación
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r backend/requirements.txt
+```
+
+## Ejecución
+
+```bash
+uvicorn app.main:app --reload --factory --app-dir backend
+```
+
+Cada router devuelve respuestas de marcador de posición y contiene comentarios `TODO` para guiar la implementación real.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,5 @@
+"""Application package for the Gestor de Requisitos backend."""
+
+from .main import app, create_app
+
+__all__ = ["app", "create_app"]

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,0 +1,12 @@
+"""Expose API routers for the FastAPI application."""
+
+from . import auth, chat_messages, files, projects, requirements, state_machine
+
+__all__ = [
+    "auth",
+    "chat_messages",
+    "files",
+    "projects",
+    "requirements",
+    "state_machine",
+]

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,0 +1,70 @@
+"""Authentication and user profile API routes."""
+
+from fastapi import APIRouter, status
+
+from ..schemas import (
+    TokenResponse,
+    UserLogin,
+    UserPreferencesUpdate,
+    UserRegister,
+    UserResponse,
+    UserUpdate,
+)
+
+router = APIRouter()
+
+
+@router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
+def register_user(payload: UserRegister) -> TokenResponse:
+    """Register a new user and return an authentication token placeholder."""
+    # TODO: implement user registration logic
+    return TokenResponse(access_token="dummy-token")
+
+
+@router.post("/login", response_model=TokenResponse)
+def login_user(payload: UserLogin) -> TokenResponse:
+    """Authenticate a user and return a token placeholder."""
+    # TODO: implement authentication logic
+    return TokenResponse(access_token="dummy-token")
+
+
+@router.get("/me", response_model=UserResponse)
+def get_current_user() -> UserResponse:
+    """Return information about the authenticated user."""
+    # TODO: fetch the current user from persistence
+    return UserResponse(
+        id=0,
+        username="placeholder",
+        email="placeholder@example.com",
+        avatar=None,
+        is_active=True,
+        preferences=None,
+    )
+
+
+@router.put("/me", response_model=UserResponse)
+def update_current_user(payload: UserUpdate) -> UserResponse:
+    """Update user profile information."""
+    # TODO: persist the update in the data layer
+    return UserResponse(
+        id=0,
+        username=payload.username or "placeholder",
+        email=payload.email or "placeholder@example.com",
+        avatar=payload.avatar,
+        is_active=True,
+        preferences=None,
+    )
+
+
+@router.put("/preferences", response_model=UserResponse)
+def update_user_preferences(payload: UserPreferencesUpdate) -> UserResponse:
+    """Update user preferences and return the updated user."""
+    # TODO: persist preferences and return updated user data
+    return UserResponse(
+        id=0,
+        username="placeholder",
+        email="placeholder@example.com",
+        avatar=None,
+        is_active=True,
+        preferences=payload,
+    )

--- a/backend/app/api/chat_messages.py
+++ b/backend/app/api/chat_messages.py
@@ -1,0 +1,28 @@
+"""Chat message API routes."""
+
+from datetime import datetime, timezone
+from typing import List
+
+from fastapi import APIRouter, status
+
+from ..schemas import ChatMessageCreate, ChatMessageResponse
+
+router = APIRouter()
+
+
+@router.get("/project/{project_id}", response_model=List[ChatMessageResponse])
+def list_chat_messages(project_id: int) -> List[ChatMessageResponse]:
+    """Return all chat messages for the provided project."""
+    # TODO: query chat history from persistence
+    return []
+
+
+@router.post("/", response_model=ChatMessageResponse, status_code=status.HTTP_201_CREATED)
+def create_chat_message(payload: ChatMessageCreate) -> ChatMessageResponse:
+    """Store a new chat message and return it."""
+    # TODO: persist chat message
+    return ChatMessageResponse(
+        id=0,
+        created_at=datetime.now(timezone.utc),
+        **payload.model_dump(),
+    )

--- a/backend/app/api/files.py
+++ b/backend/app/api/files.py
@@ -1,0 +1,30 @@
+"""File management API routes."""
+
+from typing import List
+
+from fastapi import APIRouter, UploadFile, status
+
+from ..schemas import FileContentResponse, FileUploadResponse
+
+router = APIRouter()
+
+
+@router.get("/", response_model=List[FileUploadResponse])
+def list_files() -> List[FileUploadResponse]:
+    """Return metadata for uploaded files."""
+    # TODO: read file metadata from persistence
+    return []
+
+
+@router.post("/upload", response_model=FileUploadResponse, status_code=status.HTTP_201_CREATED)
+def upload_file(uploaded_file: UploadFile) -> FileUploadResponse:
+    """Upload a file and return its metadata placeholder."""
+    # TODO: handle file upload storage
+    return FileUploadResponse(id=0, name=uploaded_file.filename or "uploaded")
+
+
+@router.get("/{file_id}/requirements", response_model=FileContentResponse)
+def get_file_content(file_id: int) -> FileContentResponse:
+    """Return the plain text content for a requirements example file."""
+    # TODO: read the file content from storage
+    return FileContentResponse(id=file_id, name="placeholder.txt", content="")

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -1,0 +1,49 @@
+"""Project management API routes."""
+
+from typing import List
+
+from fastapi import APIRouter, status
+
+from ..schemas import ProjectCreate, ProjectResponse, ProjectUpdate
+
+router = APIRouter()
+
+
+@router.get("/", response_model=List[ProjectResponse])
+def list_projects() -> List[ProjectResponse]:
+    """Return the projects visible to the authenticated user."""
+    # TODO: query projects from persistence
+    return []
+
+
+@router.post("/", response_model=ProjectResponse, status_code=status.HTTP_201_CREATED)
+def create_project(payload: ProjectCreate) -> ProjectResponse:
+    """Create a new project stub."""
+    # TODO: create project in persistence layer
+    return ProjectResponse(id=0, owner_id=0, **payload.model_dump())
+
+
+@router.get("/{project_id}", response_model=ProjectResponse)
+def get_project(project_id: int) -> ProjectResponse:
+    """Retrieve a specific project by its identifier."""
+    # TODO: fetch project from persistence
+    return ProjectResponse(id=project_id, owner_id=0, name="placeholder", description=None)
+
+
+@router.put("/{project_id}", response_model=ProjectResponse)
+def update_project(project_id: int, payload: ProjectUpdate) -> ProjectResponse:
+    """Update project metadata."""
+    # TODO: persist project update
+    return ProjectResponse(
+        id=project_id,
+        owner_id=0,
+        name=payload.name or "placeholder",
+        description=payload.description,
+    )
+
+
+@router.delete("/{project_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_project(project_id: int) -> None:
+    """Delete a project by its identifier."""
+    # TODO: remove project from persistence
+    return None

--- a/backend/app/api/requirements.py
+++ b/backend/app/api/requirements.py
@@ -1,0 +1,73 @@
+"""Requirement management API routes."""
+
+from datetime import datetime, timezone
+from typing import List
+
+from fastapi import APIRouter, status
+
+from ..schemas import (
+    RequirementCreate,
+    RequirementPriority,
+    RequirementResponse,
+    RequirementStatus,
+    RequirementUpdate,
+)
+
+router = APIRouter()
+
+
+@router.get("/project/{project_id}", response_model=List[RequirementResponse])
+def list_requirements(project_id: int) -> List[RequirementResponse]:
+    """Return the requirements associated with a project."""
+    # TODO: query requirements from persistence
+    return []
+
+
+@router.post("/", response_model=RequirementResponse, status_code=status.HTTP_201_CREATED)
+def create_requirement(payload: RequirementCreate) -> RequirementResponse:
+    """Create a new requirement stub."""
+    # TODO: persist requirement data
+    now = datetime.now(timezone.utc)
+    return RequirementResponse(
+        id=0,
+        number=0,
+        owner_id=0,
+        project_id=payload.project_id,
+        created_at=now,
+        updated_at=now,
+        **payload.model_dump(exclude={"project_id"}),
+    )
+
+
+@router.put("/{requirement_id}", response_model=RequirementResponse)
+def update_requirement(requirement_id: int, payload: RequirementUpdate) -> RequirementResponse:
+    """Update an existing requirement."""
+    # TODO: apply requirement update in persistence
+    now = datetime.now(timezone.utc)
+    return RequirementResponse(
+        id=requirement_id,
+        number=0,
+        owner_id=0,
+        project_id=0,
+        created_at=now,
+        updated_at=now,
+        description=payload.description or "placeholder",
+        status=payload.status or RequirementStatus.draft,
+        category=payload.category,
+        priority=payload.priority or RequirementPriority.medium,
+        visual_reference=payload.visual_reference,
+    )
+
+
+@router.delete("/{requirement_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_requirement(requirement_id: int) -> None:
+    """Delete a requirement by its identifier."""
+    # TODO: remove requirement from persistence
+    return None
+
+
+@router.post("/generate", response_model=List[RequirementResponse])
+def generate_requirements() -> List[RequirementResponse]:
+    """Trigger AI-assisted requirement generation."""
+    # TODO: integrate with AI service
+    return []

--- a/backend/app/api/state_machine.py
+++ b/backend/app/api/state_machine.py
@@ -1,0 +1,30 @@
+"""State machine API routes."""
+
+from datetime import datetime, timezone
+from typing import List
+
+from fastapi import APIRouter, status
+
+from ..schemas import StateMachineCreate, StateMachineResponse
+
+router = APIRouter()
+
+
+@router.post("/project/{project_id}", response_model=StateMachineResponse, status_code=status.HTTP_201_CREATED)
+def record_state_transition(project_id: int, payload: StateMachineCreate) -> StateMachineResponse:
+    """Persist a new state machine transition."""
+    # TODO: persist transition in data store
+    return StateMachineResponse(
+        id=0,
+        project_id=project_id,
+        state=payload.state,
+        extra=payload.extra,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+@router.get("/project/{project_id}", response_model=List[StateMachineResponse])
+def list_state_transitions(project_id: int) -> List[StateMachineResponse]:
+    """Retrieve the state machine history for a project."""
+    # TODO: fetch state machine history
+    return []

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,22 @@
+"""FastAPI application entry point for the requirements manager backend."""
+
+from fastapi import FastAPI
+
+from .api import auth, chat_messages, files, projects, requirements, state_machine
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application instance."""
+    app = FastAPI(title="Gestor de Requisitos API")
+
+    app.include_router(auth.router, prefix="/auth", tags=["auth"])
+    app.include_router(projects.router, prefix="/projects", tags=["projects"])
+    app.include_router(chat_messages.router, prefix="/chat_messages", tags=["chat"])
+    app.include_router(state_machine.router, prefix="/state_machine", tags=["state_machine"])
+    app.include_router(requirements.router, prefix="/requirements", tags=["requirements"])
+    app.include_router(files.router, prefix="/files", tags=["files"])
+
+    return app
+
+
+app = create_app()

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,0 +1,48 @@
+"""Aggregate exports for Pydantic schemas."""
+
+from .chat import ChatMessageCreate, ChatMessageResponse, ChatSender
+from .file import FileContentResponse, FileUploadResponse
+from .project import ProjectCreate, ProjectResponse, ProjectUpdate
+from .requirement import (
+    RequirementCreate,
+    RequirementPriority,
+    RequirementResponse,
+    RequirementStatus,
+    RequirementUpdate,
+)
+from .state_machine import ConversationState, StateMachineCreate, StateMachineResponse
+from .user import (
+    TokenResponse,
+    UserLogin,
+    UserPreferences,
+    UserPreferencesUpdate,
+    UserRegister,
+    UserResponse,
+    UserUpdate,
+)
+
+__all__ = [
+    "ChatMessageCreate",
+    "ChatMessageResponse",
+    "ChatSender",
+    "FileContentResponse",
+    "FileUploadResponse",
+    "ProjectCreate",
+    "ProjectResponse",
+    "ProjectUpdate",
+    "RequirementCreate",
+    "RequirementPriority",
+    "RequirementResponse",
+    "RequirementStatus",
+    "RequirementUpdate",
+    "ConversationState",
+    "StateMachineCreate",
+    "StateMachineResponse",
+    "TokenResponse",
+    "UserLogin",
+    "UserPreferences",
+    "UserPreferencesUpdate",
+    "UserRegister",
+    "UserResponse",
+    "UserUpdate",
+]

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -1,0 +1,36 @@
+"""Schemas for chat messages and AI interactions."""
+
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class ChatSender(str, Enum):
+    user = "user"
+    ai = "ai"
+
+
+class ChatMessageBase(BaseModel):
+    """Common fields for chat messages."""
+
+    content: str
+    sender: ChatSender
+    project_id: int
+    state: Optional[str] = None
+    language: Optional[str] = None
+    example_samples: Optional[List[int]] = None
+
+
+class ChatMessageCreate(ChatMessageBase):
+    """Payload for creating a new chat message."""
+
+    pass
+
+
+class ChatMessageResponse(ChatMessageBase):
+    """Chat message representation returned by the API."""
+
+    id: int
+    created_at: datetime

--- a/backend/app/schemas/file.py
+++ b/backend/app/schemas/file.py
@@ -1,0 +1,22 @@
+"""Schemas describing uploaded files and their contents."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class FileUploadResponse(BaseModel):
+    """Metadata returned after uploading a file."""
+
+    id: int
+    name: str
+    uploaded_at: Optional[datetime] = None
+
+
+class FileContentResponse(BaseModel):
+    """Plain text representation of a requirement example file."""
+
+    id: int
+    name: str
+    content: str

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -1,0 +1,34 @@
+"""Schemas describing project resources."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class ProjectBase(BaseModel):
+    """Shared attributes for project representations."""
+
+    name: str
+    description: Optional[str] = None
+
+
+class ProjectCreate(ProjectBase):
+    """Payload for creating a new project."""
+
+    pass
+
+
+class ProjectUpdate(ProjectBase):
+    """Payload for updating an existing project."""
+
+    name: Optional[str] = None
+
+
+class ProjectResponse(ProjectBase):
+    """Project data returned in API responses."""
+
+    id: int
+    owner_id: int
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None

--- a/backend/app/schemas/requirement.py
+++ b/backend/app/schemas/requirement.py
@@ -1,0 +1,56 @@
+"""Schemas describing requirement resources."""
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class RequirementStatus(str, Enum):
+    draft = "draft"
+    in_progress = "in_progress"
+    completed = "completed"
+
+
+class RequirementPriority(str, Enum):
+    low = "low"
+    medium = "medium"
+    high = "high"
+
+
+class RequirementBase(BaseModel):
+    """Common fields for requirement requests and responses."""
+
+    description: str
+    status: RequirementStatus
+    category: Optional[str] = None
+    priority: RequirementPriority
+    visual_reference: Optional[str] = None
+
+
+class RequirementCreate(RequirementBase):
+    """Payload for creating a new requirement."""
+
+    project_id: int
+
+
+class RequirementUpdate(BaseModel):
+    """Payload for updating an existing requirement."""
+
+    description: Optional[str] = None
+    status: Optional[RequirementStatus] = None
+    category: Optional[str] = None
+    priority: Optional[RequirementPriority] = None
+    visual_reference: Optional[str] = None
+
+
+class RequirementResponse(RequirementBase):
+    """Requirement representation returned by the API."""
+
+    id: int
+    number: int
+    owner_id: int
+    project_id: int
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/schemas/state_machine.py
+++ b/backend/app/schemas/state_machine.py
@@ -1,0 +1,36 @@
+"""Schemas describing the project state machine."""
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+
+class ConversationState(str, Enum):
+    init = "init"
+    software_questions = "software_questions"
+    new_requisites = "new_requisites"
+    analyze_requisites = "analyze_requisites"
+    stall = "stall"
+
+
+class StateMachineBase(BaseModel):
+    """Common fields for state machine transitions."""
+
+    project_id: int
+    state: ConversationState
+    extra: Optional[Any] = None
+
+
+class StateMachineCreate(StateMachineBase):
+    """Payload for storing a new state machine transition."""
+
+    pass
+
+
+class StateMachineResponse(StateMachineBase):
+    """State machine entry returned by the API."""
+
+    id: int
+    created_at: datetime

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,0 +1,70 @@
+"""Pydantic schemas for authentication and user profile endpoints."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, EmailStr
+
+
+class TokenResponse(BaseModel):
+    """Response returned after a successful authentication request."""
+
+    access_token: str
+    token_type: str = "bearer"
+
+
+class UserPreferences(BaseModel):
+    """User configurable preferences."""
+
+    language: Optional[str] = None
+    theme: Optional[str] = None
+    timezone: Optional[str] = None
+    notifications: Optional[bool] = None
+
+
+class UserBase(BaseModel):
+    """Base representation of a user."""
+
+    id: int
+    username: str
+    email: EmailStr
+    avatar: Optional[str] = None
+    is_active: bool = True
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class UserResponse(UserBase):
+    """Complete representation of the authenticated user."""
+
+    preferences: Optional[UserPreferences] = None
+
+
+class UserUpdate(BaseModel):
+    """Payload for updating basic user information."""
+
+    username: Optional[str] = None
+    email: Optional[EmailStr] = None
+    avatar: Optional[str] = None
+
+
+class UserPreferencesUpdate(UserPreferences):
+    """Payload for updating user preferences."""
+
+    pass
+
+
+class UserRegister(BaseModel):
+    """Payload for registering a new user."""
+
+    username: str
+    email: EmailStr
+    password: str
+    avatar: Optional[str] = None
+
+
+class UserLogin(BaseModel):
+    """Payload for performing a login request."""
+
+    username: str
+    password: str

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi>=0.110,<0.112
+uvicorn[standard]>=0.30,<0.31


### PR DESCRIPTION
## Summary
- scaffold a FastAPI backend application with modular routers that match the frontend needs
- define Pydantic schemas covering authentication, projects, chat, requirements, state machine, and files
- document local setup and execution steps for the new backend package

## Testing
- not run (backend skeleton only)


------
https://chatgpt.com/codex/tasks/task_e_68d7fb7deacc8332946c4801bec0c89d